### PR TITLE
rls rustfmt and num_enum

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/target
+**/*.rs.bk
+Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,5 @@
+[workspace]
+
+members = [
+  "wasm",
+]

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+num_enum = "*"

--- a/wasm/src/core/core_types.rs
+++ b/wasm/src/core/core_types.rs
@@ -13,7 +13,7 @@ pub enum ValueType {
 
 impl ValueType {
     pub fn from_byte(byte: u8) -> Result<Self> {
-        // actual values are offset by 0x7C [chrbrn]
+        // actual values are offset by 0x7C [cb]
         match byte.try_into() {
             Ok(v) => Ok(v),
             _ => Err(Error::new(

--- a/wasm/src/core/module.rs
+++ b/wasm/src/core/module.rs
@@ -16,7 +16,31 @@ pub struct Module {
 }
 
 impl Module {
-    pub fn new(types: Vec<core::FuncType>, typeidx: Vec<u32>, funcs: Vec<core::Func>, tables: Vec<core::TableType>, mems: Vec<core::MemType>, globals: Vec<core::Global>, elem: Vec<core::Element>, data: Vec<core::Data>, start: Option<u32>, imports: Vec<core::Import>, exports: Vec<core::Export>) -> Self {
-        Self { types, typeidx, funcs, tables, mems, globals, elem, data, start, imports, exports }
+    pub fn new(
+        types: Vec<core::FuncType>,
+        typeidx: Vec<u32>,
+        funcs: Vec<core::Func>,
+        tables: Vec<core::TableType>,
+        mems: Vec<core::MemType>,
+        globals: Vec<core::Global>,
+        elem: Vec<core::Element>,
+        data: Vec<core::Data>,
+        start: Option<u32>,
+        imports: Vec<core::Import>,
+        exports: Vec<core::Export>,
+    ) -> Self {
+        Self {
+            types,
+            typeidx,
+            funcs,
+            tables,
+            mems,
+            globals,
+            elem,
+            data,
+            start,
+            imports,
+            exports,
+        }
     }
 }

--- a/wasm/src/core/section.rs
+++ b/wasm/src/core/section.rs
@@ -1,6 +1,9 @@
-use std::io;
+use num_enum::TryFromPrimitive;
+use std::convert::TryInto;
+use std::io::{Error, ErrorKind, Result};
 
-#[derive(Debug,PartialEq)]
+#[derive(Debug, PartialEq, TryFromPrimitive)]
+#[repr(u8)]
 pub enum SectionType {
     CustomSection,
     TypeSection,
@@ -14,33 +17,14 @@ pub enum SectionType {
     ElementSection,
     CodeSection,
     DataSection,
-    UnknownSection(u8),
 }
 
 impl SectionType {
-    pub fn from_byte_allow_unknown(byte: u8) -> Self {
-        match byte {
-            0 => SectionType::CustomSection,
-            1 => SectionType::TypeSection,
-            2 => SectionType::ImportSection,
-            3 => SectionType::FunctionSection,
-            4 => SectionType::TableSection,
-            5 => SectionType::MemorySection,
-            6 => SectionType::GlobalSection,
-            7 => SectionType::ExportSection,
-            8 => SectionType::StartSection,
-            9 => SectionType::ElementSection,
-            10 => SectionType::CodeSection,
-            11 => SectionType::DataSection,
-
-            b => SectionType::UnknownSection(b),
-        }
-    }
-
-    pub fn from_byte(byte: u8) -> io::Result<Self> {
-        match Self::from_byte_allow_unknown(byte) {
-            SectionType::UnknownSection(b) => Err(io::Error::new(io::ErrorKind::InvalidData, format!("Unknown section type 0x{:02x}", b))),
-            r => Ok(r),
+    pub fn from_byte(byte: u8) -> Result<Self> {
+        let s: std::result::Result<SectionType, _> = byte.try_into();
+        match s {
+            Ok(s) => Ok(s),
+            _ => Err(Error::new(ErrorKind::InvalidData, "Unknown section type")),
         }
     }
 }

--- a/wasm/src/main.rs
+++ b/wasm/src/main.rs
@@ -1,11 +1,12 @@
-use std::env;
-
 mod core;
 mod parser;
 mod reader;
 
-use std::io::{self, BufReader};
-use std::fs::File;
+use std::{
+    env,
+    fs::File,
+    io::{self, BufReader},
+};
 
 use reader::TypeReader;
 

--- a/wasm/src/reader/section_reader.rs
+++ b/wasm/src/reader/section_reader.rs
@@ -1,11 +1,10 @@
-use std::io;
-use std::io::prelude::*;
+use std::io::{Read, Result};
 
-use crate::reader::{ReaderUtil, TypeReader};
 use crate::core;
+use crate::reader::{ReaderUtil, TypeReader};
 
 impl TypeReader for core::SectionType {
-    fn read<T: Read>(reader: &mut T) -> io::Result<Self> {
+    fn read<T: Read>(reader: &mut T) -> Result<Self> {
         Self::from_byte(reader.read_u8()?)
     }
 }


### PR DESCRIPTION
rustfmt did the reformatting.  I just tried out the num_enum crate to match integers to enum values. Also played around with the nested use syntax in case that interests you. Oh, also added a workspace Cargo.toml at top level (above wasm dir) and .gitignore.