### PR TITLE
Replaced io::Result with anyhow::Result

### DIFF
--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -8,3 +8,4 @@ edition = "2018"
 
 [dependencies]
 num_enum = "*"
+anyhow = "1.0"

--- a/wasm/src/core/callable.rs
+++ b/wasm/src/core/callable.rs
@@ -1,6 +1,5 @@
-use std::io;
-
 use crate::core::{Expr, ExpressionExecutor, ExpressionStore, Func, FuncType, Locals, Stack};
+use anyhow::Result;
 
 #[derive(Debug)]
 pub struct WasmExprCallable {
@@ -15,11 +14,7 @@ pub enum Callable {
 }
 
 impl Callable {
-    pub fn call<Store: ExpressionStore>(
-        &self,
-        stack: &mut Stack,
-        store: &mut Store,
-    ) -> io::Result<()> {
+    pub fn call<Store: ExpressionStore>(&self, stack: &mut Stack, store: &mut Store) -> Result<()> {
         match &self {
             Callable::WasmExpr(e) => e.call(stack, store),
         }
@@ -35,7 +30,7 @@ impl WasmExprCallable {
         })
     }
 
-    fn call<Store: ExpressionStore>(&self, stack: &mut Stack, store: &mut Store) -> io::Result<()> {
+    fn call<Store: ExpressionStore>(&self, stack: &mut Stack, store: &mut Store) -> Result<()> {
         // I haven't done any support for locals or parameters or returns at this point.
         // Mostly just because I don't need to do the support for it yet to test simple value setting
         // and it is a lot of type checking boilerplate

--- a/wasm/src/core/core_types.rs
+++ b/wasm/src/core/core_types.rs
@@ -1,8 +1,7 @@
+use crate::parser::InstructionSource;
+use anyhow::{anyhow, Result};
 use num_enum::TryFromPrimitive;
 use std::convert::TryInto;
-use std::io::{Error, ErrorKind, Result};
-
-use crate::parser::InstructionSource;
 
 #[derive(Debug, Clone, PartialEq, TryFromPrimitive)]
 #[repr(u8)]
@@ -18,10 +17,7 @@ impl ValueType {
         // actual values are offset by 0x7C [cb]
         match byte.try_into() {
             Ok(v) => Ok(v),
-            _ => Err(Error::new(
-                ErrorKind::InvalidData,
-                format!("Invalid value type byte 0x{:02x}", byte),
-            )),
+            _ => Err(anyhow!("Invalid value type byte 0x{:02x}", byte)),
         }
     }
 }
@@ -37,7 +33,7 @@ impl MutableType {
     pub fn from_byte(byte: u8) -> Result<Self> {
         match byte.try_into() {
             Ok(b) => Ok(b),
-            _ => Err(Error::new(ErrorKind::InvalidData, "Unknown mutable type")),
+            _ => Err(anyhow!("Unknown mutable type")),
         }
     }
 }
@@ -52,7 +48,7 @@ impl ElemType {
     pub fn from_byte(byte: u8) -> Result<Self> {
         match byte.try_into() {
             Ok(s) => Ok(s),
-            _ => Err(Error::new(ErrorKind::InvalidData, "Unknown funcref type")),
+            _ => Err(anyhow!("Unknown funcref type")),
         }
     }
 }

--- a/wasm/src/core/global.rs
+++ b/wasm/src/core/global.rs
@@ -1,6 +1,5 @@
-use std::io;
-
 use crate::core::{stack_entry::StackEntry, GlobalType, ValueType};
+use anyhow::{anyhow, Result};
 
 #[derive(Debug)]
 pub struct Global {
@@ -8,41 +7,29 @@ pub struct Global {
     value: StackEntry,
 }
 
-fn check_value_type(global_type: &GlobalType, value: StackEntry) -> io::Result<StackEntry> {
+fn check_value_type(global_type: &GlobalType, value: StackEntry) -> Result<StackEntry> {
     match global_type.value_type() {
         ValueType::I32 => match value {
             StackEntry::I32Entry(i) => Ok(StackEntry::I32Entry(i)),
-            _ => Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                "Global value type mismatch",
-            )),
+            _ => Err(anyhow!("Global value type mismatch")),
         },
         ValueType::I64 => match value {
             StackEntry::I64Entry(i) => Ok(StackEntry::I64Entry(i)),
-            _ => Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                "Global value type mismatch",
-            )),
+            _ => Err(anyhow!("Global value type mismatch")),
         },
         ValueType::F32 => match value {
             StackEntry::F32Entry(i) => Ok(StackEntry::F32Entry(i)),
-            _ => Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                "Global value type mismatch",
-            )),
+            _ => Err(anyhow!("Global value type mismatch")),
         },
         ValueType::F64 => match value {
             StackEntry::F64Entry(i) => Ok(StackEntry::F64Entry(i)),
-            _ => Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                "Global value type mismatch",
-            )),
+            _ => Err(anyhow!("Global value type mismatch")),
         },
     }
 }
 
 impl Global {
-    pub fn new(global_type: GlobalType, value: StackEntry) -> io::Result<Self> {
+    pub fn new(global_type: GlobalType, value: StackEntry) -> Result<Self> {
         let value = check_value_type(&global_type, value)?;
 
         Ok(Global { global_type, value })
@@ -65,15 +52,12 @@ impl Global {
         &self.value
     }
 
-    pub fn set_value(&mut self, value: StackEntry) -> io::Result<()> {
+    pub fn set_value(&mut self, value: StackEntry) -> Result<()> {
         if self.is_mutable() {
             self.value = check_value_type(self.global_type(), value)?;
             Ok(())
         } else {
-            Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                "Cannot mutate constant value",
-            ))
+            Err(anyhow!("Cannot mutate constant value"))
         }
     }
 }

--- a/wasm/src/core/resolver.rs
+++ b/wasm/src/core/resolver.rs
@@ -1,5 +1,5 @@
+use anyhow::{anyhow, Result};
 use std::cell::RefCell;
-use std::io;
 use std::rc::Rc;
 
 use crate::core::{Callable, FuncType, Global, GlobalType, MemType, Memory, Table, TableType};
@@ -10,25 +10,25 @@ pub trait Resolver {
         mod_name: &str,
         name: &str,
         func_type: &FuncType,
-    ) -> io::Result<Rc<RefCell<Callable>>>;
+    ) -> Result<Rc<RefCell<Callable>>>;
     fn resolve_table(
         &self,
         mod_name: &str,
         name: &str,
         table_type: &TableType,
-    ) -> io::Result<Rc<RefCell<Table>>>;
+    ) -> Result<Rc<RefCell<Table>>>;
     fn resolve_memory(
         &self,
         mod_name: &str,
         name: &str,
         mem_type: &MemType,
-    ) -> io::Result<Rc<RefCell<Memory>>>;
+    ) -> Result<Rc<RefCell<Memory>>>;
     fn resolve_global(
         &self,
         mod_name: &str,
         name: &str,
         global_type: &GlobalType,
-    ) -> io::Result<Rc<RefCell<Global>>>;
+    ) -> Result<Rc<RefCell<Global>>>;
 }
 
 pub struct EmptyResolver {}
@@ -39,44 +39,32 @@ impl Resolver for EmptyResolver {
         mod_name: &str,
         name: &str,
         _func_type: &FuncType,
-    ) -> io::Result<Rc<RefCell<Callable>>> {
-        Err(io::Error::new(
-            io::ErrorKind::InvalidData,
-            format!("Imported function {}:{} not found", mod_name, name),
-        ))
+    ) -> Result<Rc<RefCell<Callable>>> {
+        Err(anyhow!("Imported function {}:{} not found", mod_name, name))
     }
     fn resolve_table(
         &self,
         mod_name: &str,
         name: &str,
         _table_type: &TableType,
-    ) -> io::Result<Rc<RefCell<Table>>> {
-        Err(io::Error::new(
-            io::ErrorKind::InvalidData,
-            format!("Imported table {}:{} not found", mod_name, name),
-        ))
+    ) -> Result<Rc<RefCell<Table>>> {
+        Err(anyhow!("Imported table {}:{} not found", mod_name, name))
     }
     fn resolve_memory(
         &self,
         mod_name: &str,
         name: &str,
         _mem_type: &MemType,
-    ) -> io::Result<Rc<RefCell<Memory>>> {
-        Err(io::Error::new(
-            io::ErrorKind::InvalidData,
-            format!("Imported memory {}:{} not found", mod_name, name),
-        ))
+    ) -> Result<Rc<RefCell<Memory>>> {
+        Err(anyhow!("Imported memory {}:{} not found", mod_name, name))
     }
     fn resolve_global(
         &self,
         mod_name: &str,
         name: &str,
         _global_type: &GlobalType,
-    ) -> io::Result<Rc<RefCell<Global>>> {
-        Err(io::Error::new(
-            io::ErrorKind::InvalidData,
-            format!("Imported global {}:{} not found", mod_name, name),
-        ))
+    ) -> Result<Rc<RefCell<Global>>> {
+        Err(anyhow!("Imported global {}:{} not found", mod_name, name))
     }
 }
 

--- a/wasm/src/core/section.rs
+++ b/wasm/src/core/section.rs
@@ -1,7 +1,7 @@
-use num_enum::TryFromPrimitive;
-use std::io::{Error, ErrorKind, Read, Result};
-
 use crate::reader::{ReaderUtil, TypeReader};
+use anyhow::{anyhow, Result};
+use num_enum::TryFromPrimitive;
+use std::io::Read;
 
 #[derive(Debug, PartialEq, TryFromPrimitive)]
 #[repr(u8)]
@@ -24,7 +24,7 @@ impl TypeReader for SectionType {
     fn read<T: Read>(reader: &mut T) -> Result<Self> {
         match Self::try_from_primitive(reader.read_u8()?) {
             Ok(s) => Ok(s),
-            _ => Err(Error::new(ErrorKind::InvalidData, "Unknown section type")),
+            _ => Err(anyhow!("Unknown section type")),
         }
     }
 }

--- a/wasm/src/core/stack_entry.rs
+++ b/wasm/src/core/stack_entry.rs
@@ -113,7 +113,7 @@ impl TryFrom<StackEntry> for f64 {
 
 pub trait StackEntryValueType: Sized {
     type Error;
-    
+
     fn from_value(self) -> StackEntry;
     fn try_into_value(entry: StackEntry) -> Result<Self, Self::Error>;
 }

--- a/wasm/src/main.rs
+++ b/wasm/src/main.rs
@@ -2,25 +2,22 @@ mod core;
 mod parser;
 mod reader;
 
+#[cfg(test)]
+use anyhow::anyhow;
+use anyhow::{Context, Result};
 use std::env;
 
-#[cfg(test)]
-use anyhow::{Result, anyhow};
-
-fn main() {
+fn main() -> Result<()> {
     let args: Vec<String> = env::args().collect();
 
     if args.len() < 2 {
         println!("wasm [mod_name]");
     } else {
-        match core::Module::load_module_from_path(&args[1], core::EmptyResolver::instance()) {
-            Err(e) => println!("Failed to read module from {} - {}", &args[1], e),
-            Ok(module) => {
-                println!("Module {:?}", module);
-                println!("Done");
-            }
-        }
+        core::Module::load_module_from_path(&args[1], core::EmptyResolver::instance())
+            .with_context(|| format!("Failed to read module from {}", &args[1]))?;
     }
+
+    Ok(())
 }
 
 #[cfg(test)]

--- a/wasm/src/main.rs
+++ b/wasm/src/main.rs
@@ -5,7 +5,7 @@ mod reader;
 use std::env;
 
 #[cfg(test)]
-use std::io::{Error, ErrorKind, Result};
+use anyhow::{Result, anyhow};
 
 fn main() {
     let args: Vec<String> = env::args().collect();
@@ -55,10 +55,7 @@ mod test {
             name: &str,
             _func_type: &FuncType,
         ) -> Result<Rc<RefCell<Callable>>> {
-            Err(Error::new(
-                ErrorKind::InvalidData,
-                format!("Imported function {}:{} not found", mod_name, name),
-            ))
+            Err(anyhow!("Imported function {}:{} not found", mod_name, name))
         }
         fn resolve_table(
             &self,
@@ -66,10 +63,7 @@ mod test {
             name: &str,
             _table_type: &TableType,
         ) -> Result<Rc<RefCell<Table>>> {
-            Err(Error::new(
-                ErrorKind::InvalidData,
-                format!("Imported table {}:{} not found", mod_name, name),
-            ))
+            Err(anyhow!("Imported table {}:{} not found", mod_name, name))
         }
         fn resolve_memory(
             &self,
@@ -77,10 +71,7 @@ mod test {
             name: &str,
             _mem_type: &MemType,
         ) -> Result<Rc<RefCell<Memory>>> {
-            Err(Error::new(
-                ErrorKind::InvalidData,
-                format!("Imported memory {}:{} not found", mod_name, name),
-            ))
+            Err(anyhow!("Imported memory {}:{} not found", mod_name, name))
         }
         fn resolve_global(
             &self,
@@ -92,16 +83,10 @@ mod test {
                 if global_type.clone() == self.global_zero.borrow().global_type().clone() {
                     Ok(self.global_zero.clone())
                 } else {
-                    Err(Error::new(
-                        ErrorKind::InvalidData,
-                        format!("Global import {}:{} type mismatch", mod_name, name),
-                    ))
+                    Err(anyhow!("Global import {}:{} type mismatch", mod_name, name))
                 }
             } else {
-                Err(Error::new(
-                    ErrorKind::InvalidData,
-                    format!("Imported global {}:{} not found", mod_name, name),
-                ))
+                Err(anyhow!("Imported global {}:{} not found", mod_name, name))
             }
         }
     }

--- a/wasm/src/parser/expression_reader.rs
+++ b/wasm/src/parser/expression_reader.rs
@@ -1,7 +1,7 @@
+use crate::parser::{InstructionAccumulator, InstructionCategory};
+use anyhow;
 use std::io;
 use std::io::prelude::*;
-
-use crate::parser::{InstructionAccumulator, InstructionCategory};
 
 struct ReaderInstructionAccumulator<'a, T: Read> {
     reader: &'a mut T, // Where we get the instructions from
@@ -21,7 +21,7 @@ where
         }
     }
 
-    pub fn move_to_next(&mut self) -> io::Result<bool> {
+    pub fn move_to_next(&mut self) -> anyhow::Result<bool> {
         // Move past the current instruction
         self.next_inst = self.buf.len();
 
@@ -44,7 +44,7 @@ impl<'a, T> InstructionAccumulator for ReaderInstructionAccumulator<'a, T>
 where
     T: io::Read,
 {
-    fn ensure_bytes(&mut self, bytes: usize) -> io::Result<()> {
+    fn ensure_bytes(&mut self, bytes: usize) -> anyhow::Result<()> {
         let required_bytes = self.next_inst + bytes;
         const BUF_SIZE: usize = 16;
         let mut buf: [u8; BUF_SIZE] = [0; BUF_SIZE];
@@ -70,7 +70,7 @@ where
     }
 }
 
-pub fn read_expression_bytes<T: Read>(reader: &mut T) -> io::Result<Vec<u8>> {
+pub fn read_expression_bytes<T: Read>(reader: &mut T) -> anyhow::Result<Vec<u8>> {
     let mut acc = ReaderInstructionAccumulator::new(reader);
 
     while acc.move_to_next()? {

--- a/wasm/src/parser/instruction_accumulator.rs
+++ b/wasm/src/parser/instruction_accumulator.rs
@@ -1,15 +1,15 @@
+use anyhow::{anyhow, Result};
 use std::convert::TryFrom;
-use std::io;
 
 pub trait InstructionAccumulator {
-    fn ensure_bytes(&mut self, bytes: usize) -> io::Result<()>;
+    fn ensure_bytes(&mut self, bytes: usize) -> Result<()>;
     fn get_bytes(&self, offset: usize, length: usize) -> &[u8];
 
     fn get_byte(&self, offset: usize) -> u8 {
         self.get_bytes(offset, 1)[0]
     }
 
-    fn ensure_leb_at(&mut self, offset: usize) -> io::Result<usize> {
+    fn ensure_leb_at(&mut self, offset: usize) -> Result<usize> {
         let mut number_length: usize = 1;
         loop {
             self.ensure_bytes(offset + number_length)?;
@@ -79,10 +79,10 @@ pub trait InstructionAccumulator {
                 // At this point we have a shift bit unsigned number, so we need to sign extend it.
                 // This ought to work.
                 let mut result = unsafe { std::mem::transmute(result) };
-                
+
                 if shift < 32 {
-                    result = result << (32-shift);
-                    result = result >> (32-shift);
+                    result = result << (32 - shift);
+                    result = result >> (32 - shift);
                 }
 
                 return result;
@@ -147,10 +147,10 @@ pub trait InstructionAccumulator {
                 // At this point we have a shift bit unsigned number, so we need to sign extend it.
                 // This ought to work.
                 let mut result = unsafe { std::mem::transmute(result) };
-                
+
                 if shift < 64 {
-                    result = result << (64-shift);
-                    result = result >> (64-shift);
+                    result = result << (64 - shift);
+                    result = result >> (64 - shift);
                 }
 
                 return result;
@@ -181,12 +181,9 @@ pub struct SliceInstructionAccumulator<'a> {
 }
 
 impl<'a> InstructionAccumulator for SliceInstructionAccumulator<'a> {
-    fn ensure_bytes(&mut self, bytes: usize) -> io::Result<()> {
+    fn ensure_bytes(&mut self, bytes: usize) -> Result<()> {
         if bytes > self.slice.len() {
-            Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                "Not enough instruction bytes in expression",
-            ))
+            Err(anyhow!("Not enough instruction bytes in expression"))
         } else {
             Ok(())
         }

--- a/wasm/src/parser/instruction_iterator.rs
+++ b/wasm/src/parser/instruction_iterator.rs
@@ -1,6 +1,5 @@
-use std::io;
-
 use crate::parser::{self, InstructionAccumulator};
+use anyhow::{anyhow, Result};
 
 #[derive(Debug)]
 pub struct Instruction<'a> {
@@ -101,7 +100,7 @@ impl<'a, Source: InstructionSource> InstructionIterator<'a, Source> {
         }
     }
 
-    fn next_internal(&mut self) -> io::Result<Instruction<'a>> {
+    fn next_internal(&mut self) -> Result<Instruction<'a>> {
         // So, we can forget about any previous instruction now and move on
         self.current_instr_start = self.current_instr_end;
 
@@ -122,7 +121,7 @@ impl<'a, Source: InstructionSource> InstructionIterator<'a, Source> {
 }
 
 impl<'a, Source: InstructionSource> Iterator for InstructionIterator<'a, Source> {
-    type Item = io::Result<Instruction<'a>>;
+    type Item = Result<Instruction<'a>>;
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.current_instr_end < self.source.get_instruction_bytes().len() {
@@ -156,12 +155,9 @@ impl<'a, Source: InstructionSource> InstructionSource for InstructionIterator<'a
 impl<'a, Source: InstructionSource> parser::InstructionAccumulator
     for InstructionIterator<'a, Source>
 {
-    fn ensure_bytes(&mut self, bytes: usize) -> io::Result<()> {
+    fn ensure_bytes(&mut self, bytes: usize) -> Result<()> {
         if (self.current_instr_start + bytes) > self.source.get_instruction_bytes().len() {
-            Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                "Not enough instruction bytes in expression",
-            ))
+            Err(anyhow!("Not enough instruction bytes in expression"))
         } else {
             Ok(())
         }

--- a/wasm/src/reader/reader_util.rs
+++ b/wasm/src/reader/reader_util.rs
@@ -1,29 +1,29 @@
+use anyhow::{anyhow, Result};
 use std::convert::TryFrom;
 use std::io;
 
 pub trait ReaderUtil {
-    fn read_u8(&mut self) -> std::result::Result<u8, std::io::Error>;
-    fn read_leb_u32(&mut self) -> std::result::Result<u32, std::io::Error>;
-    fn read_leb_usize(&mut self) -> std::result::Result<usize, std::io::Error>;
-    fn read_vec<R, T: Fn(&mut Self) -> std::io::Result<R>>(
-        &mut self,
-        read_fn: T,
-    ) -> std::io::Result<Vec<R>>;
-    fn read_name(&mut self) -> std::io::Result<String>;
-    fn read_bytes_to_end(&mut self) -> std::io::Result<Vec<u8>>;
+    fn read_u8(&mut self) -> Result<u8>;
+    fn read_leb_u32(&mut self) -> Result<u32>;
+    fn read_leb_usize(&mut self) -> Result<usize>;
+
+    fn read_vec<R, T: Fn(&mut Self) -> Result<R>>(&mut self, read_fn: T) -> Result<Vec<R>>;
+
+    fn read_name(&mut self) -> Result<String>;
+    fn read_bytes_to_end(&mut self) -> Result<Vec<u8>>;
 }
 
 impl<T> ReaderUtil for T
 where
     T: io::Read,
 {
-    fn read_u8(&mut self) -> std::result::Result<u8, std::io::Error> {
+    fn read_u8(&mut self) -> Result<u8> {
         let mut buf: [u8; 1] = [0; 1];
         self.read_exact(&mut buf)?;
         Ok(buf[0])
     }
 
-    fn read_leb_u32(&mut self) -> std::result::Result<u32, std::io::Error> {
+    fn read_leb_u32(&mut self) -> Result<u32> {
         let mut result: u32 = 0;
         let mut shift = 0;
 
@@ -37,14 +37,11 @@ where
         }
     }
 
-    fn read_leb_usize(&mut self) -> io::Result<usize> {
+    fn read_leb_usize(&mut self) -> Result<usize> {
         Ok(usize::try_from(self.read_leb_u32()?).unwrap())
     }
 
-    fn read_vec<R, T2: Fn(&mut Self) -> std::io::Result<R>>(
-        &mut self,
-        read_fn: T2,
-    ) -> std::io::Result<Vec<R>> {
+    fn read_vec<R, T2: Fn(&mut Self) -> Result<R>>(&mut self, read_fn: T2) -> Result<Vec<R>> {
         let vector_length = self.read_leb_u32()?;
         let mut ret = Vec::with_capacity(usize::try_from(vector_length).unwrap());
 
@@ -55,19 +52,16 @@ where
         Ok(ret)
     }
 
-    fn read_name(&mut self) -> std::io::Result<String> {
+    fn read_name(&mut self) -> Result<String> {
         let bytes = self.read_vec(Self::read_u8)?;
 
         match String::from_utf8(bytes) {
             Ok(s) => Ok(s),
-            Err(_) => Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                "Invalid UTF8 in name",
-            )),
+            Err(_) => Err(anyhow!("Invalid UTF8 in name")),
         }
     }
 
-    fn read_bytes_to_end(&mut self) -> std::io::Result<Vec<u8>> {
+    fn read_bytes_to_end(&mut self) -> Result<Vec<u8>> {
         let mut bytes: Vec<u8> = Vec::new();
         self.read_to_end(&mut bytes)?;
         Ok(bytes)


### PR DESCRIPTION
I replaced all std::io::Results with anyhow::Results. [Anyhow](https://docs.rs/anyhow/1.0.26/anyhow/) is quite awesome.  
As a consequence, all InvalidData errors are now generic anyhow string errors. But that's I think ok as that wasn't ever used. If we want to do so, in the future this will also allow us to easily integrate more Error types, maybe using [thiserrror](https://github.com/dtolnay/thiserror) crate or even better [err_derive](https://docs.rs/crate/err-derive/0.2.1) ?

Also this would allow us to decorate errors in a nicer way using [with_context](https://docs.rs/anyhow/1.0.26/anyhow/trait.Context.html). For example usage you can check main.rs, but also it can be used to decorate io::Error or even transform options into results with extra data like so:
```
    let path = &it.path;
    let content = fs::read(path)
        .with_context(|| format!("Failed to read instrs from {}", path.display()))?;
```